### PR TITLE
fix: Fix typescript issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
 
 import { GlobalStyles } from 'styles/globalStyles'
-import * as S from './AppStyles.ts'
+import * as S from './AppStyles'
 import Navigation from 'components/common/header/navigation'
 import Home from 'pages/home'
 import Destination from 'pages/destination'
@@ -11,7 +11,7 @@ import Technology from 'pages/technology'
 
 function App() {
   const [path, setPath] = React.useState(window.location.pathname)
-  const handlePath = (currentPath) => {
+  const handlePath = (currentPath: string) => {
     console.log(path)
 
     setPath(currentPath)

--- a/src/AppStyles.ts
+++ b/src/AppStyles.ts
@@ -12,20 +12,22 @@ import BgImageMobileTechnology from 'assets/technology/background-technology-mob
 import BgImageTabletTechnology from 'assets/technology/background-technology-tablet.jpg'
 import BgImageDesktopTechnology from 'assets/technology/background-technology-desktop.jpg'
 
+import { device } from 'utils/media-query'
+
 // require(`./assets${currentPage}/background-crew-mobile.jpg`).default
-const imagesMobile = {
+const imagesMobile: any = {
   '/': BgImageMobileHome,
   '/destination': BgImageMobileDestination,
   '/crew': BgImageMobileCrew,
   '/technology': BgImageMobileTechnology,
 }
-const imagesTablet = {
+const imagesTablet: any = {
   '/': BgImageTabletHome,
   '/destination': BgImageTabletDestination,
   '/crew': BgImageTabletCrew,
   '/technology': BgImageTabletTechnology,
 }
-const imagesDesktop = {
+const imagesDesktop: any = {
   '/': BgImageDesktopHome,
   '/destination': BgImageDesktopDestination,
   '/crew': BgImageDesktopCrew,
@@ -43,13 +45,13 @@ export const PageWrapper = styled.div`
   background-position: center center;
   background-size: cover;
 
-  @media (min-width: 576px) {
+  @media ${device.tablet} {
     background-image: ${(props: IPath) =>
       `url(${imagesTablet[props.currentPage]})}`};
   }
 
-  @media (min-width: 850px) {
+  @media ${device.desktop} {
     background-image: ${(props: IPath) =>
       `url(${imagesDesktop[props.currentPage]})}`};
-  } ;;
+  }
 `

--- a/src/AppStyles.ts
+++ b/src/AppStyles.ts
@@ -12,7 +12,7 @@ import BgImageMobileTechnology from 'assets/technology/background-technology-mob
 import BgImageTabletTechnology from 'assets/technology/background-technology-tablet.jpg'
 import BgImageDesktopTechnology from 'assets/technology/background-technology-desktop.jpg'
 
-import { device } from 'utils/media-query'
+import { device } from 'utils/media-query-all'
 
 // require(`./assets${currentPage}/background-crew-mobile.jpg`).default
 const imagesMobile: any = {

--- a/src/components/common/header/navigation/index.tsx
+++ b/src/components/common/header/navigation/index.tsx
@@ -48,9 +48,7 @@ const Navigation = () => {
         {isDesktop ? <S.Line /> : null}
 
         <nav>
-          <S.MenuWrapper mq={mq}>
-            {renderNavigation()}
-          </S.MenuWrapper>
+          <S.MenuWrapper mq={mq}>{renderNavigation()}</S.MenuWrapper>
         </nav>
       </S.Container>
     )

--- a/src/components/common/header/navigation/styles.tsx
+++ b/src/components/common/header/navigation/styles.tsx
@@ -6,7 +6,7 @@ interface CommonProps {
 }
 
 export const Container = styled.section<CommonProps>`
-  margin-block: 2em;
+  padding-block: 2em;
   display: flex;
   justify-content: flex-end;
 

--- a/src/pages/crew/index.tsx
+++ b/src/pages/crew/index.tsx
@@ -2,10 +2,10 @@ import * as React from 'react'
 import * as S from './crewStyles'
 import CrewMember from 'components/crewMember'
 
-const Crew = ({ onPath }) => {
+const Crew = ({ onPath }: any) => {
   React.useEffect(() => {
     onPath(window.location.pathname)
-  }, [])
+  }, [onPath])
 
   return (
     <S.CrewWrapper>

--- a/src/pages/destination/index.tsx
+++ b/src/pages/destination/index.tsx
@@ -2,10 +2,10 @@ import * as React from 'react'
 import Title from 'components/common/title'
 import Stuff from 'components/destination/stuff'
 
-const Destination = ({ onPath }) => {
+const Destination = ({ onPath }: any) => {
   React.useEffect(() => {
     onPath(window.location.pathname)
-  }, [])
+  }, [onPath])
   return (
     <div>
       <Title title="destination" />

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -2,10 +2,10 @@ import * as React from 'react'
 import Title from 'components/common/title'
 import Stuff from 'components/home/stuff'
 
-const Home = ({ onPath }) => {
+const Home = ({ onPath }: any) => {
   React.useEffect(() => {
     onPath(window.location.pathname)
-  }, [])
+  }, [onPath])
   return (
     <div>
       <Title title="home" />

--- a/src/pages/technology/index.tsx
+++ b/src/pages/technology/index.tsx
@@ -9,10 +9,10 @@ import desktopBackground from 'assets/technology/background-technology-desktop.j
 import tabletBackground from 'assets/technology/background-technology-tablet.jpg'
 import mobileBackground from 'assets/technology/background-technology-mobile.jpg'
 
-const Technology = ({ onPath }) => {
+const Technology = ({ onPath }: any) => {
   React.useEffect(() => {
     onPath(window.location.pathname)
-  }, [])
+  }, [onPath])
   const mq = useMediaQuery()
   const { isDesktop, isTablet, isMobile } = mq
   const [tabIndex, setTabIndex] = React.useState(0)

--- a/src/utils/media-query-all.tsx
+++ b/src/utils/media-query-all.tsx
@@ -14,7 +14,7 @@ const size: Dictionary = {
   lg: 992,
 }
 
-const device: MediaQueries = {
+export const device: MediaQueries = {
   mobile: `(max-width: ${size.sm}px)`,
   tablet: `(min-width: ${size.sm + 1}px) and (max-width: ${size.md}px)`,
   desktop: `(min-width: ${size.md + 1}px)`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "importHelpers": true,
+    "removeComments": true,
     "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
I've managed to correct the typescript issues I was getting. I wonder why I was getting those errors on my side but not on your side. We're probably using different lint rules. Every change you see on this PR has the sole purpose of fixing those typescript issues, except those explained below:

- `Appstyles.ts`

    You used different breakpoints from those I was using for the `<Navigation>` component, for example. What happened? The component was changing out of sync with the background image. We've got to agree on where the breakpoints will be. I'm open to changing the numbers I proposed, although I used some fairly standard, well-established numbers. But we **must** use a *single source of truth*, so I changed your media queries to use the breakpoints defined on `common/media-query-all.tsx`. When we go on a call we can decide where exactly the breakpoints will be.

- `navigation/styles.tsx`

    I had to change `margin-block` on line 9 to `padding-block`. That was necessary because the solution you came up with for the background-images was to add an extra `<div>` wrapping the whole app. The margin I had set to the `<Navigation>` component was interfering with the positioning of that `<div>`. Try changing `padding-block` to `margin-block` and see what happens.

    When I first saw your solution I went 'nooooooo!!!' haha. Come to think of it now, it's not bad! However, I think it should have been implemented in a way that the background-image is attached to the body of the document. If you let me, I'd love to make the necessary changes for that to happen.

Finally, did you notice that when you click to change tabs in the crew page, it causes an image shift in the background image? I wonder why that is. I can help you figure it out why if you want.
