### PR TITLE
feat: Attach background-image to the body of the DOM

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { BrowserRouter as Router, Route } from 'react-router-dom'
+import { Route, useLocation } from 'react-router-dom'
+import useMediaQuery from 'utils/media-query-all'
+import { getUrl } from 'utils/bg-img-url'
 
 import { GlobalStyles } from 'styles/globalStyles'
-import * as S from './AppStyles'
 import Navigation from 'components/common/header/navigation'
 import Home from 'pages/home'
 import Destination from 'pages/destination'
@@ -10,33 +11,34 @@ import Crew from 'pages/crew'
 import Technology from 'pages/technology'
 
 function App() {
-  const [path, setPath] = React.useState(window.location.pathname)
-  const handlePath = (currentPath: string) => {
-    console.log(path)
+  let location = useLocation()
+  const mq = useMediaQuery()
 
-    setPath(currentPath)
-  }
+  React.useEffect(() => {
+    const url = getUrl(location.pathname, mq)
+    const position =
+      mq.isTablet || mq.isDesktop ? 'center center' : 'bottom center'
+    document.body.style.backgroundImage = `url(${url})`
+    document.body.style.backgroundSize = 'cover'
+    document.body.style.backgroundPosition = position
+  }, [location, mq])
 
   return (
     <>
       <GlobalStyles />
-      <S.PageWrapper currentPage={path}>
-        <Router>
-          <Navigation />
-          <Route exact path="/">
-            <Home onPath={handlePath} />
-          </Route>
-          <Route exact path="/destination">
-            <Destination onPath={handlePath} />
-          </Route>
-          <Route exact path="/crew">
-            <Crew onPath={handlePath} />
-          </Route>
-          <Route exact path="/technology">
-            <Technology onPath={handlePath} />
-          </Route>
-        </Router>
-      </S.PageWrapper>
+      <Navigation />
+      <Route exact path="/">
+        <Home />
+      </Route>
+      <Route exact path="/destination">
+        <Destination />
+      </Route>
+      <Route exact path="/crew">
+        <Crew />
+      </Route>
+      <Route exact path="/technology">
+        <Technology />
+      </Route>
     </>
   )
 }

--- a/src/components/common/header/navigation/index.tsx
+++ b/src/components/common/header/navigation/index.tsx
@@ -7,7 +7,7 @@ import close from 'assets/shared/icon-close.svg'
 import hamburger from 'assets/shared/icon-hamburger.svg'
 
 const Navigation = () => {
-  const [showMenu, setShowMenu] = React.useState(true)
+  const [showMenu, setShowMenu] = React.useState(false)
   const mq = useMediaQuery()
   const { isDesktop, isTablet, isMobile } = mq
 

--- a/src/components/common/title.tsx
+++ b/src/components/common/title.tsx
@@ -2,9 +2,7 @@ import useMediaQuery from 'utils/media-query-all'
 import * as S from './title.styles'
 
 interface TitleProps {
-  // i've made number optional for now just so that it doesn't break  the app
-  // but it should be required in the future
-  number?: string
+  number: string
   title: string
   className?: string
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
 import App from './App'
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Router>
+      <App />
+    </Router>
   </React.StrictMode>,
   document.getElementById('root')
 )

--- a/src/pages/crew/index.tsx
+++ b/src/pages/crew/index.tsx
@@ -2,11 +2,7 @@ import * as React from 'react'
 import * as S from './crewStyles'
 import CrewMember from 'components/crewMember'
 
-const Crew = ({ onPath }: any) => {
-  React.useEffect(() => {
-    onPath(window.location.pathname)
-  }, [onPath])
-
+const Crew = () => {
   return (
     <S.CrewWrapper>
       <S.PTitle number={'02'} title="meet your crew" />

--- a/src/pages/destination/index.tsx
+++ b/src/pages/destination/index.tsx
@@ -2,13 +2,10 @@ import * as React from 'react'
 import Title from 'components/common/title'
 import Stuff from 'components/destination/stuff'
 
-const Destination = ({ onPath }: any) => {
-  React.useEffect(() => {
-    onPath(window.location.pathname)
-  }, [onPath])
+const Destination = () => {
   return (
     <div>
-      <Title title="destination" />
+      <Title number='01' title="destination" />
       <Stuff />
     </div>
   )

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -2,13 +2,10 @@ import * as React from 'react'
 import Title from 'components/common/title'
 import Stuff from 'components/home/stuff'
 
-const Home = ({ onPath }: any) => {
-  React.useEffect(() => {
-    onPath(window.location.pathname)
-  }, [onPath])
+const Home = () => {
   return (
     <div>
-      <Title title="home" />
+      <Title number='00' title="home" />
       <Stuff />
     </div>
   )

--- a/src/pages/technology/index.tsx
+++ b/src/pages/technology/index.tsx
@@ -5,30 +5,27 @@ import data from 'utils/data.json'
 import * as S from './index.style'
 import Image from 'components/technology/image'
 
-import desktopBackground from 'assets/technology/background-technology-desktop.jpg'
-import tabletBackground from 'assets/technology/background-technology-tablet.jpg'
-import mobileBackground from 'assets/technology/background-technology-mobile.jpg'
+// import desktopBackground from 'assets/technology/background-technology-desktop.jpg'
+// import tabletBackground from 'assets/technology/background-technology-tablet.jpg'
+// import mobileBackground from 'assets/technology/background-technology-mobile.jpg'
 
-const Technology = ({ onPath }: any) => {
-  React.useEffect(() => {
-    onPath(window.location.pathname)
-  }, [onPath])
+const Technology = () => {
   const mq = useMediaQuery()
-  const { isDesktop, isTablet, isMobile } = mq
+  // const { isDesktop, isTablet, isMobile } = mq
   const [tabIndex, setTabIndex] = React.useState(0)
   const { technology } = data
 
-  React.useEffect(() => {
-    const url = isDesktop
-      ? desktopBackground
-      : isTablet
-      ? tabletBackground
-      : mobileBackground
-    const position = isTablet || isDesktop ? 'center center' : 'bottom center'
-    document.body.style.backgroundImage = `url(${url})`
-    document.body.style.backgroundSize = 'cover'
-    document.body.style.backgroundPosition = position
-  }, [isDesktop, isTablet, isMobile])
+  // React.useEffect(() => {
+  //   const url = isDesktop
+  //     ? desktopBackground
+  //     : isTablet
+  //     ? tabletBackground
+  //     : mobileBackground
+  //   const position = isTablet || isDesktop ? 'center center' : 'bottom center'
+  //   document.body.style.backgroundImage = `url(${url})`
+  //   document.body.style.backgroundSize = 'cover'
+  //   document.body.style.backgroundPosition = position
+  // }, [isDesktop, isTablet, isMobile])
 
   const handleClick = (index: number) => {
     setTabIndex(index)

--- a/src/styles/custom-properties.ts
+++ b/src/styles/custom-properties.ts
@@ -29,5 +29,6 @@ export const customProperties = css`
     font-size: var(--fs-6);
     color: hsl(var(--c-white));
     background-color: hsl(var(--c-dark));
+    transition: background-image 0.2s ease-in-out;
   }
 `

--- a/src/utils/bg-img-url.ts
+++ b/src/utils/bg-img-url.ts
@@ -1,0 +1,39 @@
+interface urlType {
+  [index: string]: { mobile: string; tablet: string; desktop: string }
+}
+
+const url: urlType = {
+  '/': {
+    mobile: 'assets/home/background-home-mobile.jpg',
+    tablet: 'assets/home/background-home-tablet.jpg',
+    desktop: 'assets/home/background-home-desktop.jpg',
+  },
+  '/destination': {
+    mobile: 'assets/destination/background-destination-mobile.jpg',
+    tablet: 'assets/destination/background-destination-tablet.jpg',
+    desktop: 'assets/destination/background-destination-desktop.jpg',
+  },
+  '/crew': {
+    mobile: 'assets/crew/background-crew-mobile.jpg',
+    tablet: 'assets/crew/background-crew-tablet.jpg',
+    desktop: 'assets/crew/background-crew-desktop.jpg',
+  },
+  '/technology': {
+    mobile: 'assets/technology/background-technology-mobile.jpg',
+    tablet: 'assets/technology/background-technology-tablet.jpg',
+    desktop: 'assets/technology/background-technology-desktop.jpg',
+  },
+}
+
+interface getUrlFn {
+  (
+    pathname: string,
+    mq: { isMobile: boolean; isTablet: boolean; isDesktop: boolean }
+  ): string
+}
+
+export const getUrl: getUrlFn = (pathname, mq) => {
+  const { isTablet, isDesktop } = mq
+  const size = isDesktop ? 'desktop' : isTablet ? 'tablet' : 'mobile'
+  return require('../' + url[pathname][size]).default
+}


### PR DESCRIPTION
This one took me some hours to get done but I've learned a few tricks on the way.

The background images are now attached to the `body` of the document. We don't need to send a callback function to each page just to get the current url anymore. I've moved the `<Router>` component to the `<App>`'s parent so that I could make use of the `useLocation()` hook from `react-router-dom` directly from the `<App>` component itself. Then I created a `getUrl` function that returns the url for the background images dynamically. I didn't even need to import all images beforehand! :-)

I've also added a quick transition to the `background-image` property just for fun. We can remove it if you think it's tacky.