### PR TITLE
fix: Set max-width to <Navigation> component

### DIFF
--- a/src/components/common/header/navigation/styles.tsx
+++ b/src/components/common/header/navigation/styles.tsx
@@ -6,6 +6,8 @@ interface CommonProps {
 }
 
 export const Container = styled.section<CommonProps>`
+  max-width: 1440px;
+  margin: 0 auto;
   padding-block: 2em;
   display: flex;
   /* justify-content: flex-end; */


### PR DESCRIPTION
It does what it says in the title, and only that.

I tried to replicate what you did this afternoon during the call, when you shrank the screen to about 300px and a bug appeared in the `<Navigation>` component. It doesn't happen on my screen! We must go on a call and share our screen again to try and understand what is happening.